### PR TITLE
Lambda Docker→zip 移行 & CI の OIDC 化

### DIFF
--- a/.github/workflows/serverless-dev.yml
+++ b/.github/workflows/serverless-dev.yml
@@ -2,6 +2,10 @@ name: serverless-dev
 
 on: pull_request
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     name: deploy
@@ -23,8 +27,7 @@ jobs:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
 
       - name: install plugins

--- a/.github/workflows/serverless-dev.yml
+++ b/.github/workflows/serverless-dev.yml
@@ -27,8 +27,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-1
 
+      - name: install plugins
+        run: npm install
+
       - name: deploy
         run: sls deploy --stage dev
         env:
           SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 
+node_modules/
+
+bootstrap
+
+env.yml
+
 .gradle/
 
 .idea/workspace.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,25 @@
-FROM ghcr.io/graalvm/native-image-community:22-muslib as build-image
-
-WORKDIR /work
-COPY ./ ./
-
-RUN microdnf install findutils
-
-RUN ./gradlew clean nativeCompile
-RUN chmod +x ./build/native/nativeCompile/lambda-kotlin-sls
-
-FROM public.ecr.aws/lambda/provided:al2
-
-COPY --from=build-image /work/build/native/nativeCompile/lambda-kotlin-sls /var/runtime/bootstrap
-
-CMD ["dummyHandler"]
+# =====================================================================
+# Docker(ECR イメージ)版の Dockerfile【旧構成・参考用にコメントアウト】
+# ---------------------------------------------------------------------
+# zip(provided.al2)版へ移行したため未使用。
+# zip 版では serverless.yml の scripts フックが
+# ghcr.io/graalvm/native-image-community:22-muslib イメージで
+# `./gradlew clean nativeCompile` を実行し、生成物を bootstrap に
+# リネームするため、この Dockerfile は不要になった。
+# ---------------------------------------------------------------------
+# FROM ghcr.io/graalvm/native-image-community:22-muslib as build-image
+#
+# WORKDIR /work
+# COPY ./ ./
+#
+# RUN microdnf install findutils
+#
+# RUN ./gradlew clean nativeCompile
+# RUN chmod +x ./build/native/nativeCompile/lambda-kotlin-sls
+#
+# FROM public.ecr.aws/lambda/provided:al2
+#
+# COPY --from=build-image /work/build/native/nativeCompile/lambda-kotlin-sls /var/runtime/bootstrap
+#
+# CMD ["dummyHandler"]
+# =====================================================================

--- a/README.md
+++ b/README.md
@@ -2,12 +2,22 @@
 
 自力でシングルバイナリなサーバーレスkotlin作ってみたやつ by Graalvm
 
-要: Docker, Serverless Framework
+要: Docker, Node.js, Serverless Framework
+
+zip(provided.al2)版で動作する。`sls deploy` 時に serverless-plugin-scripts の
+フックが GraalVM の Docker イメージで `nativeCompile` を実行し、生成された
+ネイティブバイナリを `bootstrap` にリネームして zip にパッケージングする。
 
 ```bash
+# プラグインのインストール（初回のみ）
+$ npm install
+
 # deploy
 $ sls deploy --stage <stage_name>
 
 # remove
 $ sls remove --stage <stage_name>
 ```
+
+> 旧構成の Docker(ECR イメージ)版は `serverless.yml` / `Dockerfile` に
+> コメントアウトで残してある。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "lambda-kotlin-sls",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lambda-kotlin-sls",
+      "version": "1.0.0",
+      "devDependencies": {
+        "serverless-plugin-scripts": "^1.0.2"
+      }
+    },
+    "node_modules/serverless-plugin-scripts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/serverless-plugin-scripts/-/serverless-plugin-scripts-1.0.2.tgz",
+      "integrity": "sha512-+OL9fFz5r6BXNHfpu9MDLehS/haC0fy/T3V5uJsTfLAnNsn+PzM6BmvefUfWG372hBT7piTbywB1Vl1+4LmI5Q==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lambda-kotlin-sls",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "serverless-plugin-scripts": "^1.0.2"
+  }
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,38 +1,89 @@
 service: lambda-kotlin-sls
 
+plugins:
+  - serverless-plugin-scripts
+
 custom:
   defaultStage: dev
+  scripts:
+    hooks:
+      # sls deploy / sls package 時に bootstrap を静的ビルドする。
+      # macOS / Apple Silicon でも Lambda(provided.al2, x86_64) 互換の
+      # 静的バイナリを得るため、linux/amd64 を明示して Docker でビルドする。
+      # GraalVM native-image を musl で静的リンクし、生成物を bootstrap に
+      # リネームしてパッケージ直下へ配置する。
+      'before:package:createDeploymentArtifacts': |
+        docker run --rm --platform linux/amd64 -v "$PWD":/work -w /work ghcr.io/graalvm/native-image-community:22-muslib \
+          sh -c "microdnf install -y findutils && ./gradlew clean nativeCompile && cp ./build/native/nativeCompile/lambda-kotlin-sls bootstrap && chmod +x bootstrap"
 
 provider:
   name: aws
-  runtime: provided
+  runtime: provided.al2
   timeout: 20
   region: ap-northeast-1
-  ecr:
-    images:
-      appImage:
-        path: ./
-        platform: linux/amd64
   stage: ${opt:stage, self:custom.defaultStage}
   # environment:
   #   ${file(./env.yml)}
 
+package:
+  patterns:
+    - '!./**'
+    - bootstrap
+
 functions:
+  # provided ランタイムはパッケージ直下の bootstrap を実行する。
+  # handler 文字列は _HANDLER として渡され、src/main/kotlin/main.kt の
+  # Lambda.handler("...") と一致させることで処理を振り分ける。
   hello:
-    image:
-      name: appImage
-      command:
-        - hello
+    handler: hello
     events:
       - http:
           path: test
           method: get
   world:
-    image:
-      name: appImage
-      command:
-        - world
+    handler: world
     events:
       - http:
           path: test
           method: post
+
+# =====================================================================
+# Docker(ECR イメージ)版【旧構成・参考用にコメントアウトで残す】
+# ---------------------------------------------------------------------
+# Dockerfile から ECR イメージをビルドし、image.command で各関数の
+# _HANDLER を切り替えていた。zip 版へ移行したため無効化。
+# ---------------------------------------------------------------------
+# provider:
+#   name: aws
+#   runtime: provided
+#   timeout: 20
+#   region: ap-northeast-1
+#   ecr:
+#     images:
+#       appImage:
+#         path: ./
+#         platform: linux/amd64
+#   stage: ${opt:stage, self:custom.defaultStage}
+#   # environment:
+#   #   ${file(./env.yml)}
+#
+# functions:
+#   hello:
+#     image:
+#       name: appImage
+#       command:
+#         - hello
+#     events:
+#       - http:
+#           path: test
+#           method: get
+#   world:
+#     image:
+#       name: appImage
+#       command:
+#         - world
+#     events:
+#       - http:
+#           path: test
+#           method: post
+# =====================================================================

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,9 +12,10 @@ custom:
       # 静的バイナリを得るため、linux/amd64 を明示して Docker でビルドする。
       # GraalVM native-image を musl で静的リンクし、生成物を bootstrap に
       # リネームしてパッケージ直下へ配置する。
+      # GraalVM イメージは ENTRYPOINT が native-image のため --entrypoint sh で上書きする。
       'before:package:createDeploymentArtifacts': |
-        docker run --rm --platform linux/amd64 -v "$PWD":/work -w /work ghcr.io/graalvm/native-image-community:22-muslib \
-          sh -c "microdnf install -y findutils && ./gradlew clean nativeCompile && cp ./build/native/nativeCompile/lambda-kotlin-sls bootstrap && chmod +x bootstrap"
+        docker run --rm --platform linux/amd64 --entrypoint sh -v "$PWD":/work -w /work ghcr.io/graalvm/native-image-community:22-muslib \
+          -c "microdnf install -y findutils && ./gradlew clean nativeCompile && cp ./build/native/nativeCompile/lambda-kotlin-sls bootstrap && chmod +x bootstrap"
 
 provider:
   name: aws


### PR DESCRIPTION
## 概要
[lambda-crystal-sls](https://github.com/limit7412/lambda-crystal-sls) を参考に、Lambda のデプロイ方式を Docker(ECR イメージ) から zip(provided.al2) へ移行し、あわせて GitHub Actions の AWS 認証を OIDC 化した。

## 変更点
### Docker → zip 移行
- `serverless.yml`: `runtime: provided.al2` + `serverless-plugin-scripts` の `before:package:createDeploymentArtifacts` フックで GraalVM イメージ上で `nativeCompile` し、生成バイナリを `bootstrap` にリネームして zip パッケージング
- functions を `image.command` → `handler` 指定に変更（`_HANDLER` ディスパッチは既存ロジックのまま）
- `Dockerfile` / 旧 `serverless.yml` の Docker 版設定はサンプルとしてコメントアウトで残置
- `package.json` 追加（プラグイン）、`.gitignore`・`README.md` 更新

### CI の OIDC 化
- アクセスキーから OIDC ロール (`ga-deploy-oicd_lambda-kotlin-sls`) の AssumeRole に変更
- `permissions: id-token: write` 追加、`role-to-assume: ${{ secrets.AWS_ROLE_ARN }}` を使用

## 動作確認
- ローカルで docker 版を `sls remove`、zip 版を `sls deploy` 済み
- GET/POST 両エンドポイントが HTTP 200 で正常応答することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)